### PR TITLE
feat(dhis2): retry failed POST requests

### DIFF
--- a/openhexa/toolbox/dhis2/api.py
+++ b/openhexa/toolbox/dhis2/api.py
@@ -31,8 +31,8 @@ class Api:
             max_retries=Retry(
                 total=3,
                 backoff_factor=5,
-                allowed_methods=["HEAD", "GET"],
-                status_forcelist=[429, 500, 502, 503, 504],
+                allowed_methods=["HEAD", "GET", "POST"],
+                status_forcelist=[409, 429, 500, 502, 503, 504],
             )
         )
         self.session.mount("https://", adapter)


### PR DESCRIPTION
Data pipelines that push data to DHIS2 can suffer from 409 errors occasionally.

Example:

```
openhexa.sdk.pipelines.pipeline.PipelineRunError: Pipeline era5_import_dhis2 failed:
409 Client Error: for url: https://dhis2.endop-niger.temp.bluesquare.org/api/dataValueSets?dryRun=True&importStrategy=CREATE_AND_UPDATE
```

I was not able to find the reason behind the error and running the pipeline again usually fixes the problem.