### PR TITLE
fix(dhis2): do not drop columns when joining object names

### DIFF
--- a/openhexa/toolbox/dhis2/dataframe.py
+++ b/openhexa/toolbox/dhis2/dataframe.py
@@ -1119,6 +1119,9 @@ def join_object_names(
         )
 
     COLUMNS = [
+        "dataset_name",
+        "dataset_id",
+        "dataset_period_type",
         "data_element_id",
         "data_element_name",
         "indicator_id",
@@ -1134,5 +1137,8 @@ def join_object_names(
         "created",
         "last_updated",
     ]
+
+    # if additional columns were present in the original dataframe, keep them at the end
+    COLUMNS += [col for col in df.columns if col not in COLUMNS]
 
     return df.select([col for col in COLUMNS if col in df.columns])


### PR DESCRIPTION
The `join_object_names()` function was dropping any column in the input dataframe not found in the expected column list. Now, the function still sort columns according to that same list, and keep any additional column at the end.