### PR TITLE
fix(era5): data availability checks always fail

### DIFF
--- a/openhexa/toolbox/era5/cds.py
+++ b/openhexa/toolbox/era5/cds.py
@@ -159,7 +159,7 @@ def list_datetimes_in_dataset(ds: xr.Dataset) -> list[datetime]:
         if dtime in dtimes:
             continue
         non_null = ds.sel(time=time)[var].notnull().sum().values.item()
-        if non_null >= 0:
+        if non_null > 0:
             dtimes.append(dtime)
 
     return dtimes

--- a/openhexa/toolbox/era5/cds.py
+++ b/openhexa/toolbox/era5/cds.py
@@ -159,9 +159,7 @@ def list_datetimes_in_dataset(ds: xr.Dataset) -> list[datetime]:
         if dtime in dtimes:
             continue
         non_null = ds.sel(time=time)[var].notnull().sum().values.item()
-        non_null /= len(ds.latitude) * len(ds.longitude)
-        n_steps = len(ds.step) if ds.step.ndim else 1
-        if non_null >= n_steps:
+        if non_null >= 0:
             dtimes.append(dtime)
 
     return dtimes


### PR DESCRIPTION
Data availability checks when listing datetimes in a directory were always failing because the threshold for non-null values was too high. This led to data being downloaded again and again.

For example, hours for which we had 3% of null values where treated as unavailable.

Reduced the threshold to "> 0" instead of "= 100%". Which means as long as we have have at least 1 non-null data value for a given datetime, we consider that datetime as being already available and we don't download it again.