### PR TITLE
fix: add conda build to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,4 +65,4 @@ jobs:
         env:
           VERSION: ${{ env.VERSION }}
         run: |
-          conda build . --channel conda-forge --channel bioconda
+          conda build . --channel conda-forge --channel bioconda --channel blsqtech


### PR DESCRIPTION
We have two jobs in parallel :

ci for every branch commit
publish on release
When we publish we do conda build and it fails when we forget to add packages, but as the build status is only displayed from CI flow, we never get notified until docker-images build fails.
I have added packages build to CI flow so we notified in CI if there is an unmet dependency

Closes: https://bluesquare.atlassian.net/browse/HEXA-1331?atlOrigin=eyJpIjoiYWU4Y2ZiYjI1ZWRlNGQ3Njk0ZDEyMzgzMzAwNjc1YjUiLCJwIjoiaiJ9