### PR TITLE
fix: emitting events with same instance of client is leading to corrupted lineage (HEXA-1332)

### DIFF
--- a/openhexa/toolbox/lineage/client.py
+++ b/openhexa/toolbox/lineage/client.py
@@ -75,7 +75,12 @@ class OpenHexaOpenLineageClient:
                 nominalEndTime=end_time.isoformat() if end_time else None,
             )
 
-        run = Run(runId=self.run_id, facets=run_facets)
+        if task_name:
+            base_uuid = uuid.UUID(self.run_id)
+            task_run_id = str(uuid.uuid5(base_uuid, task_name))
+        else:
+            task_run_id = self.run_id
+        run = Run(runId=task_run_id, facets=run_facets)
 
         job_facets = {}
         if sql:

--- a/tests/lineage/test_lineage.py
+++ b/tests/lineage/test_lineage.py
@@ -64,3 +64,50 @@ class TestLineage:
         assert mock_responses.calls[0].request.url == "http://localhost:3000/api/v1/lineage"
         assert mock_responses.calls[0].request.method == "POST"
         assert json.loads(mock_responses.calls[0].request.body) == emit_event_example
+
+    def test_unique_run_ids_for_different_tasks(self, mock_responses):
+        from openhexa.toolbox import lineage
+        from openhexa.toolbox.lineage import EventType
+
+        lineage.init_client(
+            url="http://localhost:3000",
+            workspace_slug="default",
+            pipeline_slug="test_pipeline",
+            pipeline_run_id="abe36e6a-8af7-4718-a753-c6d2054d1ecf",
+        )
+
+        mock_responses.add(responses.POST, "http://localhost:3000/api/v1/lineage", json={}, status=200)
+
+        lineage.event(
+            event_type=EventType.COMPLETE,
+            task_name="test1",
+            outputs=["dataset1.csv"],
+        )
+
+        lineage.event(
+            event_type=EventType.COMPLETE,
+            task_name="test2",
+            outputs=["dataset2.csv"],
+        )
+
+        lineage.event(
+            event_type=EventType.COMPLETE,
+            task_name="test1",
+            outputs=["dataset2.csv"],
+        )
+
+
+        assert len(mock_responses.calls) == 3
+        
+        event1 = json.loads(mock_responses.calls[0].request.body)
+        event2 = json.loads(mock_responses.calls[1].request.body)
+        event3 = json.loads(mock_responses.calls[2].request.body)
+
+        
+        assert event1["run"]["runId"] == "381a6a74-ad3b-549c-967b-58585197f90a"
+        assert event2["run"]["runId"] == "d8bb693b-23bb-54f0-8605-29032f10d5d5"
+        assert event3["run"]["runId"] == "381a6a74-ad3b-549c-967b-58585197f90a" # Same task, same run ID
+        
+        assert event1["outputs"][0]["name"] == "dataset1.csv"
+        assert event2["outputs"][0]["name"] == "dataset2.csv"
+        assert event3["outputs"][0]["name"] == "dataset2.csv"


### PR DESCRIPTION
```
from openhexa.toolbox import lineage
from uuid import uuid1

lineage_id = uuid1()

lineage.init_client(
        url="https://lineage.demo.openhexa.org",
        workspace_slug="testabcd",
        pipeline_slug="dhis2_metadata_extract",
        pipeline_run_id=f"{lineage_id}",
    )
dataset1 = lineage._client.create_output_dataset("dataset1.csv")
lineage.event(
            event_type=EventType.COMPLETE,
            task_name="test1",
            outputs=[dataset1],
        )
dataset2 = lineage._client.create_output_dataset("dataset2.csv")
lineage.event(
            event_type=EventType.COMPLETE,
            task_name="test2",
            outputs=[dataset2],
        )
```
Is leading `test2` to have 2 datasets as output because openlineage considers the run id as a group by key 