### PR TITLE
fix(era5): enforce consistency between datasets

### DIFF
--- a/openhexa/toolbox/era5/aggregate.py
+++ b/openhexa/toolbox/era5/aggregate.py
@@ -128,9 +128,15 @@ def merge(data_dir: Path | str) -> xr.Dataset:
 
     files = data_dir.glob("*.grib")
     ds = xr.open_dataset(next(files), engine="cfgrib")
+    if "time" not in ds.dims and "time" in ds.coords:
+        # xarray drop the time dimension if it has only one value
+        ds = ds.expand_dims("time")
 
     for f in files:
-        ds = xr.concat([ds, xr.open_dataset(f, engine="cfgrib")], dim="tmp_dim").max(dim="tmp_dim")
+        ds2 = xr.open_dataset(f, engine="cfgrib")
+        if "time" not in ds2.dims and "time" in ds2.coords:
+            ds2 = ds2.expand_dims("time")
+        ds = xr.concat([ds, ds2], dim="tmp_dim").max(dim="tmp_dim")
 
     return ds
 

--- a/openhexa/toolbox/era5/aggregate.py
+++ b/openhexa/toolbox/era5/aggregate.py
@@ -127,13 +127,13 @@ def merge(data_dir: Path | str) -> xr.Dataset:
         data_dir = Path(data_dir)
 
     files = data_dir.glob("*.grib")
-    ds = xr.open_dataset(next(files), engine="cfgrib")
+    ds = xr.open_dataset(next(files), engine="cfgrib", decode_timedelta=True)
     if "time" not in ds.dims and "time" in ds.coords:
         # xarray drop the time dimension if it has only one value
         ds = ds.expand_dims("time")
 
     for f in files:
-        ds2 = xr.open_dataset(f, engine="cfgrib")
+        ds2 = xr.open_dataset(f, engine="cfgrib", decode_timedelta=True)
         if "time" not in ds2.dims and "time" in ds2.coords:
             ds2 = ds2.expand_dims("time")
         ds = xr.concat([ds, ds2], dim="tmp_dim").max(dim="tmp_dim")

--- a/openhexa/toolbox/era5/cds.py
+++ b/openhexa/toolbox/era5/cds.py
@@ -175,7 +175,7 @@ def list_datetimes_in_dir(data_dir: Path) -> list[datetime]:
     dtimes = []
 
     for f in data_dir.glob("*.grib"):
-        ds = xr.open_dataset(f, engine="cfgrib")
+        ds = xr.open_dataset(f, engine="cfgrib", decode_timedelta=True)
         # xarray drop the time dimension if it has only one value, so we expand it
         # to make sure structure is consistent with other datasets
         if "time" not in ds.dims and "time" in ds.coords:


### PR DESCRIPTION
* Always check for zip archives in GRIB files and decompress them if needed
* Always remove .idx files
* Expand time dimension if needed