### PR TITLE
DSDE-243: fix(dhis2): Get all pages for tracker endpoint

### DIFF
--- a/openhexa/toolbox/dhis2/api.py
+++ b/openhexa/toolbox/dhis2/api.py
@@ -146,7 +146,7 @@ class Api:
         r = self.get(endpoint=endpoint, params=params, use_cache=use_cache)
         yield r
 
-        if "pager" in r:
+        if ("pager" in r) and ("tracker" not in endpoint):
             logger.debug(f"Pager found, using page size {params['pageSize']}")
             params["page"] = r["pager"]["page"]
             while "nextPage" in r["pager"]:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - pip
   run:
     - python>=3.9,<3.15
-    - requests
+    - requests >=2.31,<2.33
     - python-dateutil
     - pandas
     - shapely


### PR DESCRIPTION
The tracker endpoint does have pager in the return, but it does not keep count of the pages.
In order to get all of the pages, for the tracker endpoint we need to look at the pageCount

I have tested this locally. I am not sure if there are any other tests I should be doing. 

I have also added a version for the requests library -- the tests were failing without it, but I am not completely able to understand if this is a good idea. 