### PR TITLE
fix(kobo): paginate get_data and infer schema on all rows in to_dataframe

### DIFF
--- a/openhexa/toolbox/kobo/api.py
+++ b/openhexa/toolbox/kobo/api.py
@@ -103,9 +103,17 @@ class Survey:
 
     def get_data(self, limit: int = 1000) -> List[dict]:
         """Download survey data."""
-        r = self.client.session.get(self.meta["data"], params={"limit": limit})
-        r.raise_for_status()
-        return r.json().get("results")
+        results = []
+        url = self.meta["data"]
+        params = {"limit": limit}
+        while url:
+            r = self.client.session.get(url, params=params)
+            r.raise_for_status()
+            payload = r.json()
+            results.extend(payload.get("results", []))
+            url = payload.get("next")
+            params = None
+        return results
 
     @cached_property
     def _xpaths_labels_mapping(self) -> dict:

--- a/openhexa/toolbox/kobo/utils.py
+++ b/openhexa/toolbox/kobo/utils.py
@@ -63,7 +63,7 @@ def rename_columns(df: pl.DataFrame) -> pl.DataFrame:
 def to_dataframe(survey: Survey) -> pl.DataFrame:
     """Get survey data as a polars dataframe."""
     rows = survey.get_data()
-    df = pl.DataFrame(rows)
+    df = pl.DataFrame(rows, infer_schema_length=None)
 
     # columns with no data in the survey are not returned by the api
     # add the missing columns as String with only null values


### PR DESCRIPTION
Hey Yann, 

J'ai remarqué 2 problèmes dans les fonctions de la toolbox kobo utiisées pour télécharger les données des formulaires:

- `get_data `: la fonction ne parcourt pas les pages de résultats et s'arrête donc à la première requête, soit 1000 entrées au maximum (valeur par défaut du paramètre `limit`). Comme `count` et `next` sont écartés de la réponse, la troncature est totalement silencieuse. Conséquence concrète : la fiche kobo consolidée compte 1203 entrées, dont 203 ne sont jamais extraites. J'ai modifié la fonction pour suivre la pagination jusqu'au bout et récupérer l'intégralité des soumissions.

- `to_dataframe` : `pl.DataFrame()` déduit son schéma à partir des 100 premières lignes seulement (défaut de `infer_schema_length`). Or Kobo omet purement et simplement les clés des questions non répondues au lieu de renvoyer une valeur nulle : une colonne absente des 100 premières soumissions n'entre donc jamais dans le schéma et est écartée du dataframe pour toutes les lignes, y compris celles où elle est renseignée. C'est exactement le cas de la fiche consolidée pour les champs ajoutés récemment (ex. le nom de l'entreprise en charge des travaux), vides sur les anciennes soumissions et remplis sur les nouvelles. J'ai passé `infer_schema_length=None` pour que le schéma soit déduit sur l'ensemble des lignes. À noter que les deux correctifs vont de pair : sans la pagination, l'inférence ne portait de toute façon que sur les 1000 lignes récupérées.